### PR TITLE
[WIP] Add HtmlFormInputCheckbox

### DIFF
--- a/src/main/java/htmlflow/elements/HtmlFormInputCheckbox.java
+++ b/src/main/java/htmlflow/elements/HtmlFormInputCheckbox.java
@@ -1,0 +1,40 @@
+package htmlflow.elements;
+
+import htmlflow.HtmlWriter;
+import htmlflow.elements.ElementType;
+
+import java.io.PrintStream;
+
+/**
+ * Creates an Html checkbox
+ */
+public class HtmlFormInputCheckbox implements HtmlWriter<Object> {
+    PrintStream out;
+    String name;
+
+    @Override
+    public void write(final int depth, final Object model) {
+        out.println("<input type=\"checkbox\" name=\"" + name + "\">");
+        out.println("</input>");
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see htmlflow.HtmlElement#getElementName()
+     */
+    public String getElementName() {
+        return ElementType.INPUT.toString();
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see htmlflow.HtmlWriter#setPrintStream(java.io.PrintStream)
+     */
+    @Override
+    public HtmlWriter<Object> setPrintStream(final PrintStream out) {
+        this.out = out;
+        return this;
+    }
+}


### PR DESCRIPTION
Working on an example where I wanted to convert a form in a PDF to an HTML form and found that I needed to be able to create checkboxes since they show up in PDF forms. (If interested see [here](https://github.com/datalogics/pdf-java-toolkit-samples/pull/110)).

There might be a better way to do this for HtmlFlow and if so, please let me know. I found that this was relatively easy to add though as a convenience.

If there are other things you would like to see added to this or any modifications, just let me know. I have found HtmlFlow to be easy to use so far so anything I can do to help out, I am willing to do.

**To do**

- [ ] Update `HtmlFormInputCheckbox` to extend `HtmlSingleElement`
- [ ] Add fluent API in parent elements to enable adding `HtmlFormInputCheckbox` objects
- [ ] Include `HtmlFormInputCheckbox` in model binding
- [ ] Add tests for `HtmlFormInputCheckbox`