### PR TITLE
Support for non thread-safety views. And, minor fix on visitParentOnVoidElements.

### DIFF
--- a/src/main/java/htmlflow/DynamicHtml.java
+++ b/src/main/java/htmlflow/DynamicHtml.java
@@ -69,22 +69,22 @@ public class DynamicHtml<T> extends HtmlView<T> {
     }
 
     private DynamicHtml(PrintStream out, HtmlTemplate<T> template) {
-        this.visitor = ThreadLocal.withInitial(() -> new HtmlVisitorPrintStream(out, true));
+        this.setVisitor(() -> new HtmlVisitorPrintStream(out, true));
         this.template = template;
     }
 
     private DynamicHtml(PrintStream out, BiConsumer<DynamicHtml<T>, T> binder) {
-        this.visitor = ThreadLocal.withInitial(() -> new HtmlVisitorPrintStream(out, true));
+        this.setVisitor(() -> new HtmlVisitorPrintStream(out, true));
         this.binder = binder;
     }
 
     private DynamicHtml(HtmlTemplate<T> template) {
-        this.visitor = ThreadLocal.withInitial(() -> new HtmlVisitorStringBuilder(true));
+        this.setVisitor(() -> new HtmlVisitorStringBuilder(true));
         this.template = template;
     }
 
     private DynamicHtml(BiConsumer<DynamicHtml<T>, T> binder) {
-        this.visitor = ThreadLocal.withInitial(() -> new HtmlVisitorStringBuilder(true));
+        this.setVisitor(() -> new HtmlVisitorStringBuilder(true));
         this.binder = binder;
     }
 

--- a/src/main/java/htmlflow/HtmlVisitorCache.java
+++ b/src/main/java/htmlflow/HtmlVisitorCache.java
@@ -194,9 +194,6 @@ public abstract class HtmlVisitorCache extends ElementVisitor {
             if (!isClosed){
                 write(Tags.FINISH_TAG);
             }
-            else
-                depth--;
-
             isClosed = true;
         }
     }

--- a/src/main/java/htmlflow/StaticHtml.java
+++ b/src/main/java/htmlflow/StaticHtml.java
@@ -57,7 +57,7 @@ public class StaticHtml extends HtmlView<Object> {
     }
 
     private StaticHtml() {
-        this.visitor = ThreadLocal.withInitial(() -> new HtmlVisitorStringBuilder(false));
+        this.setVisitor(() -> new HtmlVisitorStringBuilder(false));
     }
 
     private StaticHtml(Consumer<StaticHtml>  template) {
@@ -66,7 +66,7 @@ public class StaticHtml extends HtmlView<Object> {
     }
 
     private StaticHtml(PrintStream out) {
-        this.visitor = ThreadLocal.withInitial(() -> new HtmlVisitorPrintStream(out, false));
+        this.setVisitor((() -> new HtmlVisitorPrintStream(out, false)));
     }
 
     private StaticHtml(PrintStream out, Consumer<StaticHtml> template) {

--- a/src/test/java/htmlflow/test/TestDivDetails.java
+++ b/src/test/java/htmlflow/test/TestDivDetails.java
@@ -69,7 +69,8 @@ public class TestDivDetails {
                 Stream.of(
                         new Task(3, "ISEL MPD project", "A Java library for serializing objects in HTML.", Priority.High),
                         new Task(4, "Special dinner", "Moonlight dinner!", Priority.Normal),
-                        new Task(5, "US Open Final 2018", "Juan Martin del Potro VS  Novak Djokovic", Priority.High)
+                        new Task(5, "US Open Final 2018", "Juan Martin del Potro VS  Novak Djokovic", Priority.High),
+                        new Task(9, "Web Summit 2018", "Sir Tim Berners-Lee", Priority.High)
                 ).collect(Collectors.toMap(
                         identity(),
                         task -> loadLines(format("task%d.html", task.getId()))
@@ -114,7 +115,7 @@ public class TestDivDetails {
     @Test
     public void testDivDetailsBinding() {
         ByteArrayOutputStream mem = new ByteArrayOutputStream();
-        DynamicHtml<Task> view = DynamicHtml
+        HtmlView<Task> view = DynamicHtml
             .view(new PrintStream(mem), HtmlLists::taskDetailsTemplate);
 
         expectedTaskViews
@@ -138,10 +139,13 @@ public class TestDivDetails {
 
     @Test
     public void testDivDetailsBindingWithRender() {
-        HtmlView<Task> view = DynamicHtml.view(HtmlLists::taskDetailsTemplate);
+        HtmlView<Task> view = DynamicHtml
+            .view(HtmlLists::taskDetailsTemplate)
+            .threadSafe();
         expectedTaskViews
                 .keySet()
                 .stream()
+                .parallel()
                 .map(task -> TaskHtml.of(task,
                                 htmlRender(view, task)))
                 .forEach(taskHtml -> {

--- a/src/test/java/htmlflow/test/TestWrongUseOfViews.java
+++ b/src/test/java/htmlflow/test/TestWrongUseOfViews.java
@@ -144,5 +144,24 @@ public class TestWrongUseOfViews {
             .write(new Object()); // wrong use of write with a model
 
     }
+    /**
+     * A view with a PrintStream output cannot be set to thread-safety.
+     */
+    @Test(expected = IllegalStateException.class)
+    public void testWrongUseOfThreadSafeInViewWithPrintStream(){
+        StaticHtml
+            .view(System.out)
+            .threadSafe();
+    }
+    /**
+     * A thread-safe view cannot be set with a PrintStream.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testWrongUseSetPrintStreamInThreadSafeView(){
+        StaticHtml
+            .view()
+            .threadSafe()
+            .setPrintStream(System.out);
+    }
 
 }

--- a/src/test/resources/task9.html
+++ b/src/test/resources/task9.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>
+			Task Details
+		</title>
+	</head>
+	<body>
+		Title:
+		Web Summit 2018
+		<br>
+		Description:
+		Sir Tim Berners-Lee
+		<br>
+		Priority:
+		High
+	</body>
+</html>


### PR DESCRIPTION
Support to non thread-safety views. 

HtmlView now use alternately: or visitor, or threadLocalVisitor. 

Minor fix on visitParentOnVoidElements -- removed a depth-- (not sure on this change)