### PR TITLE
Turn Views Immutable

### DIFF
--- a/src/main/java/htmlflow/HtmlVisitorCache.java
+++ b/src/main/java/htmlflow/HtmlVisitorCache.java
@@ -308,10 +308,10 @@ public abstract class HtmlVisitorCache extends ElementVisitor {
     /*=========================================================================*/
 
     @Override
-    public <Z extends Element> void visitElementRoot(Root<Z> var1) { }
+    public final <Z extends Element> void visitElementRoot(Root<Z> var1) { }
 
     @Override
-    public <Z extends Element> void visitParentRoot(Root<Z> var1) { }
+    public final <Z extends Element> void visitParentRoot(Root<Z> var1) { }
 
     /*=========================================================================*/
     /*------------      Parent Methods for Void Elements   --------------------*/

--- a/src/test/java/htmlflow/test/TestHtmlViewAsElement.java
+++ b/src/test/java/htmlflow/test/TestHtmlViewAsElement.java
@@ -38,13 +38,6 @@ public class TestHtmlViewAsElement {
     }
 
     @Test(expected = IllegalStateException.class)
-    public void testWrongRender() {
-        StaticHtml
-            .view(System.out)
-            .render();
-    }
-
-    @Test(expected = IllegalStateException.class)
     public void testWrong__use() {
         StaticHtml.view().__();
     }

--- a/src/test/java/htmlflow/test/TestWrongUseOfViews.java
+++ b/src/test/java/htmlflow/test/TestWrongUseOfViews.java
@@ -72,44 +72,6 @@ public class TestWrongUseOfViews {
     }
 
     /**
-     * Views with a PrintStream should use the method write() instead
-     * of render().
-     */
-    @Test(expected = IllegalStateException.class)
-    public void testWrongUseOfRenderInViewWithPrintStream(){
-        DynamicHtml
-            .view(System.out, (view, model) -> {
-                view.html().head().title().text("Task Details").__();
-            })
-            .render(); // Cannot use render() on views with a PrintStream
-    }
-    /**
-     * Views with a PrintStream should use the method write() instead
-     * of render().
-     */
-    @Test(expected = IllegalStateException.class)
-    public void testWrongUseOfRenderWithModelInViewWithPrintStream(){
-        DynamicHtml
-            .view(System.out, (view, model) -> {
-                view.html().head().title().text("Task Details").__();
-            })
-            .render(new Object()); // Cannot use render() on views with a PrintStream
-    }
-
-    /**
-     * Views with a PrintStream should use the method write() instead
-     * of render().
-     */
-    @Test(expected = IllegalStateException.class)
-    public void testWrongUseOfRenderWithModelAndPartialsInViewWithPrintStream(){
-        DynamicHtml
-            .view(System.out, (view, model) -> {
-                view.html().head().title().text("Task Details").__();
-            })
-            .render(new Object(), StaticHtml.view()); // Cannot use render() on views with a PrintStream
-    }
-
-    /**
      * A StaticHtml view cannot use render() with a model.
      */
     @Test(expected = UnsupportedOperationException.class)


### PR DESCRIPTION
Remove setVisitor(). Turn final all instance fields of views.  Some of these fields are initialized with lambdas (invokedynamic) which require several invocations to optimize call sites.