### PR TITLE
Resolve#125

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,0 @@
-This project includes code adapted from the Guava library, licensed under the Apache License 2.0.
-Guava is available at https://github.com/google/guava

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,2 @@
+This project includes code adapted from the Guava library, licensed under the Apache License 2.0.
+Guava is available at https://github.com/google/guava

--- a/pom.xml
+++ b/pom.xml
@@ -113,11 +113,6 @@
             <version>1.7.2</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>33.0.0-jre</version>
-        </dependency>
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/htmlflow/visitor/HtmlVisitor.java
+++ b/src/main/java/htmlflow/visitor/HtmlVisitor.java
@@ -24,8 +24,8 @@
 
 package htmlflow.visitor;
 
-import com.google.common.html.HtmlEscapers;
 import htmlflow.exceptions.HtmlFlowAppendException;
+import htmlflow.visitor.escape.HtmlEscapers;
 import org.xmlet.htmlapifaster.Area;
 import org.xmlet.htmlapifaster.Base;
 import org.xmlet.htmlapifaster.Br;

--- a/src/main/java/htmlflow/visitor/escape/HtmlEscapers.java
+++ b/src/main/java/htmlflow/visitor/escape/HtmlEscapers.java
@@ -1,0 +1,43 @@
+package htmlflow.visitor.escape;
+
+import htmlflow.visitor.escape.core.Escaper;
+import htmlflow.visitor.escape.core.Escapers;
+
+/**
+ * Utility class for HTML escaping.
+ * <p>
+ *     This class provides a static method to obtain an {@link Escaper}
+ *     for escaping HTML characters.
+ *     The returned escaper will convert special HTML characters
+ *     to their corresponding HTML entities,
+ *     such as converting `&` to `&amp;`, `<` to `&lt;`, `>` to `&gt;`, etc.
+ * </p>
+ */
+public final class HtmlEscapers {
+
+    /**
+     * Returns an {@link Escaper} for HTML escaping.
+     *
+     * @return the {@link #HTML_ESCAPER} object.
+     */
+    public static Escaper htmlEscaper() {
+        return HTML_ESCAPER;
+    }
+
+    /**
+     * A pre-configured {@link Escaper} for HTML escaping.
+     * <p>
+     *     This escaper is initialized with common HTML character replacements
+     *     such as `&`, `<`, `>`, `"`, and `'`.
+     * </p>
+     */
+    private static final Escaper HTML_ESCAPER =
+            Escapers
+                    .builder()
+                    .addScape('"', "&quot;")
+                    .addScape('\'', "&#39;")
+                    .addScape('&', "&amp;")
+                    .addScape('<', "&lt;")
+                    .addScape('>', "&gt;")
+                    .build();
+}

--- a/src/main/java/htmlflow/visitor/escape/HtmlEscapers.java
+++ b/src/main/java/htmlflow/visitor/escape/HtmlEscapers.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright (C) 2009 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package htmlflow.visitor.escape;
 
 import htmlflow.visitor.escape.core.Escaper;
@@ -6,12 +20,23 @@ import htmlflow.visitor.escape.core.Escapers;
 /**
  * Utility class for HTML escaping.
  * <p>
- *     This class provides a static method to obtain an {@link Escaper}
- *     for escaping HTML characters.
- *     The returned escaper will convert special HTML characters
- *     to their corresponding HTML entities,
- *     such as converting `&` to `&amp;`, `<` to `&lt;`, `>` to `&gt;`, etc.
+ * This class provides a static method to obtain an {@link Escaper}
+ * for escaping HTML characters.
+ * The returned escaper will convert special HTML characters
+ * to their corresponding HTML entities,
+ * such as converting `&` to `&amp;amp;`, `<` to `&amp;lt`, `>` to `&amp;gt`, etc.
  * </p>
+ * <p>
+ *     Derived and adapted from Guava's HtmlEscapers class:
+ *     <a href="https://github.com/google/guava/blob/master/guava/src/com/google/common/html/HtmlEscapers.java">guava</a>
+ * </p>
+ *
+ * <p>
+ *     Modified by Arthur Oliveira on 04-08-2025
+ * </p>
+ *
+ * @author Arthur Oliveira
+ * @author The Guava Authors
  */
 public final class HtmlEscapers {
 
@@ -27,8 +52,8 @@ public final class HtmlEscapers {
     /**
      * A pre-configured {@link Escaper} for HTML escaping.
      * <p>
-     *     This escaper is initialized with common HTML character replacements
-     *     such as `&`, `<`, `>`, `"`, and `'`.
+     * This escaper is initialized with common HTML character replacements
+     * such as `&`, `<`, `>`, `"`, and `'`.
      * </p>
      */
     private static final Escaper HTML_ESCAPER =

--- a/src/main/java/htmlflow/visitor/escape/core/ArrayBasedCharEscaper.java
+++ b/src/main/java/htmlflow/visitor/escape/core/ArrayBasedCharEscaper.java
@@ -1,0 +1,59 @@
+package htmlflow.visitor.escape.core;
+
+import java.util.Map;
+
+abstract class ArrayBasedCharEscaper extends CharEscaper {
+    private final char[][] replacements;
+    private final int replacementLength;
+    private final char safeMin;
+    private final char safeMax;
+
+
+    protected ArrayBasedCharEscaper(Map<Character, String> replacementMap, char safeMin, char safeMax) {
+        this(ArrayBasedEscaperMap.create(replacementMap), safeMin, safeMax);
+    }
+
+    protected ArrayBasedCharEscaper(ArrayBasedEscaperMap replacements, char safeMin, char safeMax) {
+        this.replacements = replacements.getEmptyReplacementArray();
+        this.replacementLength = replacements.getEmptyReplacementArray().length;
+        if (safeMax < safeMin) {
+            safeMax = Character.MAX_VALUE;
+            safeMin = Character.MIN_VALUE;
+        }
+        this.safeMin = safeMin;
+        this.safeMax = safeMax;
+    }
+
+    @Override
+    public final String escape(String code) {
+        if (code == null) {
+            throw new NullPointerException("Code cannot be null");
+        }
+        for (int idx = 0; idx < code.length(); idx++) {
+            char c = code.charAt(idx);
+            if ((c < replacementLength && replacements[c] != null) || c < safeMin || c > safeMax) {
+                return escapeSlow(code, idx);
+            }
+        }
+        return code;
+    }
+
+    @Override
+    public final char[] escape(char c) {
+        if (c < replacementLength) {
+            char[] chars = replacements[c];
+            if (chars != null) {
+                return chars;
+            }
+        }
+        if (c < safeMin || c > safeMax) {
+            return null;
+        }
+        return escapeUnsafe(c);
+    }
+
+    /**
+     * TODO: Make Documentation
+     */
+    protected abstract char[] escapeUnsafe(char c);
+}

--- a/src/main/java/htmlflow/visitor/escape/core/ArrayBasedCharEscaper.java
+++ b/src/main/java/htmlflow/visitor/escape/core/ArrayBasedCharEscaper.java
@@ -1,12 +1,70 @@
+/*
+ * Copyright (C) 2009 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package htmlflow.visitor.escape.core;
 
 import java.util.Map;
 
+/**
+ * An abstract class for escaping characters based on a replacement map.
+ * It uses an array to store replacements for characters and provides methods
+ * to escape characters and strings.
+ *
+ * <p>
+ *     Derived and adapted from Guava's ArrayBasedCharEscaper class:
+ *     <a href="https://github.com/google/guava/blob/master/guava/src/com/google/common/escape/ArrayBasedCharEscaper.java">guava</a>
+ * </p>
+ *
+ * <p>
+ *     Modified by Arthur Oliveira on 04-08-2025
+ * </p>
+ *
+ * @author Arthur Oliveira
+ * @author The Guava Authors
+ */
 abstract class ArrayBasedCharEscaper extends CharEscaper {
+    /**
+     * The array of character replacements. Each index corresponds to a character,
+     * and the value at that index is an array of characters representing the replacement.
+     * <p>
+     *     e.g., if replacements[65] is not null, it means that the character 'A' (ASCII 65)
+     *     has a replacement defined.
+     * </p>
+     */
     private final char[][] replacements;
+    /**
+     * The length of the replacement array, which is the maximum character code that can be replaced.
+     * <p>
+     * Characters with codes greater than or equal to this value are not replaced.
+     */
     private final int replacementLength;
+    /**
+     * The minimum safe character code that does not need escaping.
+     * <p>
+     * Characters below this value are considered unsafe and will be escaped.
+     */
     private final char safeMin;
+    /**
+     * The maximum safe character code that does not need escaping.
+     * <p>
+     * Characters above this value are considered unsafe and will be escaped.
+     */
     private final char safeMax;
+    /**
+     * Exception message for null code input.
+     */
+    public static final String NULL_CODE_EXCEPTION_MESSAGE = "Code cannot be null";
 
 
     protected ArrayBasedCharEscaper(Map<Character, String> replacementMap, char safeMin, char safeMax) {
@@ -14,20 +72,21 @@ abstract class ArrayBasedCharEscaper extends CharEscaper {
     }
 
     protected ArrayBasedCharEscaper(ArrayBasedEscaperMap replacements, char safeMin, char safeMax) {
-        this.replacements = replacements.getEmptyReplacementArray();
-        this.replacementLength = replacements.getEmptyReplacementArray().length;
+        this.replacements = replacements.getReplacementArray();
+        this.replacementLength = replacements.getReplacementArray().length;
         if (safeMax < safeMin) {
-            safeMax = Character.MAX_VALUE;
-            safeMin = Character.MIN_VALUE;
+            this.safeMax = Character.MAX_VALUE;
+            this.safeMin = Character.MIN_VALUE;
+        } else  {
+            this.safeMax = safeMax;
+            this.safeMin = safeMin;
         }
-        this.safeMin = safeMin;
-        this.safeMax = safeMax;
     }
 
     @Override
-    public final String escape(String code) {
+    public final String escape(String code) throws NullPointerException {
         if (code == null) {
-            throw new NullPointerException("Code cannot be null");
+            throw new NullPointerException(NULL_CODE_EXCEPTION_MESSAGE);
         }
         for (int idx = 0; idx < code.length(); idx++) {
             char c = code.charAt(idx);
@@ -46,14 +105,18 @@ abstract class ArrayBasedCharEscaper extends CharEscaper {
                 return chars;
             }
         }
-        if (c < safeMin || c > safeMax) {
+        if (c >= safeMin && c <= safeMax) {
             return null;
         }
-        return escapeUnsafe(c);
+        return escapeUnsafeChar(c);
     }
 
     /**
-     * TODO: Make Documentation
+     * Escapes a character that is not safe and does not have a replacement.
+     * This method should be implemented by subclasses to provide specific escaping logic.
+     *
+     * @param c the character to escape
+     * @return an array of characters representing the escaped version of the input character
      */
-    protected abstract char[] escapeUnsafe(char c);
+    protected abstract char[] escapeUnsafeChar(char c);
 }

--- a/src/main/java/htmlflow/visitor/escape/core/ArrayBasedEscaperMap.java
+++ b/src/main/java/htmlflow/visitor/escape/core/ArrayBasedEscaperMap.java
@@ -1,37 +1,76 @@
+/*
+ * Copyright (C) 2009 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package htmlflow.visitor.escape.core;
 
 import java.util.Map;
 
 import static java.util.Collections.max;
 
-
+/**
+ * A class that provides an array-based implementation for character escaping.
+ *
+ * <p>
+ *     This class is used to create a mapping of characters to their escape sequences,
+ *     allowing for efficient character replacement during escaping operations.
+ * </p>
+ *
+ * <p>
+ *     Derived and adapted from Guava's ArrayBasedEscaperMap class:
+ *     <a href="https://github.com/google/guava/blob/master/guava/src/com/google/common/escape/ArrayBasedEscaperMap.java">guava</a>
+ * </p>
+ *
+ * <p>
+ *     Modified by Arthur Oliveira on 04-08-2025
+ * </p>
+ *
+ * @author Arthur Oliveira
+ * @author The Guava Authors
+ */
 final class ArrayBasedEscaperMap {
+
+    /**
+     * The replacement array used for escaping characters.
+     */
+    private final char[][] replacementArray;
+
+    /**
+     * An empty replacement array used when no replacements are defined.
+     * <p>
+     *  This array is used to avoid unnecessary allocations
+     *  when there are no characters to escape.
+     */
+    private static final char[][] EMPTY_REPLACEMENT_ARRAY = new char[0][0];
+
+    /**
+     * Exception message for null replacement map.
+     */
+    private static final String NULL_MAP_EXCEPTION_MESSAGE = "Replacement map cannot be null";
 
     private ArrayBasedEscaperMap(char[][] replacementArray) {
         this.replacementArray = replacementArray;
     }
 
     /**
-     * An empty replacement array used when no replacements are defined.
-     * <p>
-    *  This array is used to avoid unnecessary allocations
-    *  when there are no characters to escape.
-     */
-    private static final char[][] EMPTY_REPLACEMENT_ARRAY = new char[0][0];
-
-    /**
      * Creates a replacement array from the given map.
      * @param replacements the map of characters to their replacement strings
      * @return an {@link ArrayBasedEscaperMap} instance containing the replacement array
+     * @throws NullPointerException if the replacements map is null
      */
     public static ArrayBasedEscaperMap create(Map<Character, String> replacements) {
         return new ArrayBasedEscaperMap(createReplacementArray(replacements));
     }
-
-    /**
-     * The replacement array used for escaping characters.
-     */
-    private final char[][] replacementArray;
 
     /**
      * Returns the replacement array used for escaping characters.
@@ -40,7 +79,7 @@ final class ArrayBasedEscaperMap {
      *
      * @return {@link #replacementArray}
      */
-    char[][] getEmptyReplacementArray() {
+    char[][] getReplacementArray() {
         return replacementArray;
     }
 
@@ -56,9 +95,9 @@ final class ArrayBasedEscaperMap {
      *
      * @throws NullPointerException if the map is null
      */
-    static char[][] createReplacementArray(Map<Character, String> map) {
+    private static char[][] createReplacementArray(Map<Character, String> map) {
         if (map == null) {
-            throw new NullPointerException("Replacement map cannot be null");
+            throw new NullPointerException(NULL_MAP_EXCEPTION_MESSAGE);
         }
         if (map.isEmpty()) {
             return EMPTY_REPLACEMENT_ARRAY;

--- a/src/main/java/htmlflow/visitor/escape/core/ArrayBasedEscaperMap.java
+++ b/src/main/java/htmlflow/visitor/escape/core/ArrayBasedEscaperMap.java
@@ -1,0 +1,73 @@
+package htmlflow.visitor.escape.core;
+
+import java.util.Map;
+
+import static java.util.Collections.max;
+
+
+final class ArrayBasedEscaperMap {
+
+    private ArrayBasedEscaperMap(char[][] replacementArray) {
+        this.replacementArray = replacementArray;
+    }
+
+    /**
+     * An empty replacement array used when no replacements are defined.
+     * <p>
+    *  This array is used to avoid unnecessary allocations
+    *  when there are no characters to escape.
+     */
+    private static final char[][] EMPTY_REPLACEMENT_ARRAY = new char[0][0];
+
+    /**
+     * Creates a replacement array from the given map.
+     * @param replacements the map of characters to their replacement strings
+     * @return an {@link ArrayBasedEscaperMap} instance containing the replacement array
+     */
+    public static ArrayBasedEscaperMap create(Map<Character, String> replacements) {
+        return new ArrayBasedEscaperMap(createReplacementArray(replacements));
+    }
+
+    /**
+     * The replacement array used for escaping characters.
+     */
+    private final char[][] replacementArray;
+
+    /**
+     * Returns the replacement array used for escaping characters.
+     * <p>
+     * This method provides access to the array that contains the character replacements.
+     *
+     * @return {@link #replacementArray}
+     */
+    char[][] getEmptyReplacementArray() {
+        return replacementArray;
+    }
+
+    /**
+     * Creates a replacement array from the given map.
+     * <p>
+     * This method constructs a character array where each index corresponds to a character,
+     * and the value at that index is the character's replacement as a character array.
+     *
+     * @param map the map of characters to their replacement strings
+     * @return a character array where each index corresponds to a character,
+     *         and the value at that index is the character's replacement as a character array
+     *
+     * @throws NullPointerException if the map is null
+     */
+    static char[][] createReplacementArray(Map<Character, String> map) {
+        if (map == null) {
+            throw new NullPointerException("Replacement map cannot be null");
+        }
+        if (map.isEmpty()) {
+            return EMPTY_REPLACEMENT_ARRAY;
+        }
+        char max = max(map.keySet());
+        char[][] replacement = new char[max + 1][];
+        for (Character c : map.keySet()) {
+            replacement[c] = map.get(c).toCharArray();
+        }
+        return replacement;
+    }
+}

--- a/src/main/java/htmlflow/visitor/escape/core/CharEscaper.java
+++ b/src/main/java/htmlflow/visitor/escape/core/CharEscaper.java
@@ -1,0 +1,119 @@
+package htmlflow.visitor.escape.core;
+
+abstract class CharEscaper extends Escaper{
+
+    /**
+     * The multiplier for the size of the escape buffer.
+     */
+    private static final int ESCAPE_PAD_MULTIPLIER = 2;
+
+    protected CharEscaper() {}
+
+    @Override
+    public String escape(String code) {
+        if (code == null) {
+            throw new NullPointerException("Code cannot be null");
+        }
+        int length = code.length();
+        for (int idx = 0; idx < length; idx++) {
+            if (escape(code.charAt(idx)) != null) {
+                return escapeSlow(code, idx);
+            }
+        }
+        return code;
+    }
+
+    /**
+     * Escapes a single character.
+     * <p>
+     *     This method is called for each character in the input string.
+     *     If the character needs to be escaped,
+     *     it should return a character array representing the escaped form.
+     *     If the character does not need to be escaped, it should return null.
+     * @param c the character to escape
+     * @return a character array representing the escaped form of the character,
+     *         or null if the character does not need to be escaped
+     */
+    protected abstract char[] escape(char c);
+
+    /**
+     * Escapes the input string starting from the specified index.
+     * <p>
+     * This method is called when at least one character in the input string
+     * needs to be escaped. It processes the string from the given index,
+     * escaping characters as necessary and returning the fully escaped string.
+     *
+     * @param code the input string to escape
+     * @param idx the index to start escaping from
+     * @return the fully escaped string
+     */
+    protected final String escapeSlow(String code, int idx) {
+        int length = code.length();
+
+        char[] escapedChars = Platform.charBufferFromTheadLocal();
+        int escapedSize = escapedChars.length;
+        int escapedIdx = 0;
+        int lastEscape = 0;
+
+        for (; idx < length; idx++) {
+            char[] escapedChar = escape(code.charAt(idx));
+
+            if (escapedChar == null) {
+                continue;
+            }
+
+            int escapedLength = escapedChar.length;
+            int charsSkipped = idx - lastEscape;
+
+            int sizeNeeded = escapedIdx + charsSkipped + escapedLength;
+            if (escapedSize < sizeNeeded) {
+                escapedSize = sizeNeeded + ESCAPE_PAD_MULTIPLIER * (length - idx);
+                escapedChars = growBuffer(escapedChars, escapedIdx, escapedSize);
+            }
+
+            if (charsSkipped > 0) {
+                code.getChars(lastEscape, idx, escapedChars, escapedIdx);
+                escapedIdx += charsSkipped;
+            }
+
+            if (escapedLength > 0) {
+                System.arraycopy(escapedChar, 0, escapedChars, escapedIdx, escapedLength);
+                escapedIdx += escapedLength;
+            }
+            lastEscape = idx + 1;
+        }
+
+        int charsLeft = length - lastEscape;
+        if (charsLeft > 0) {
+            int neededSize = escapedIdx + charsLeft;
+            if (escapedSize < neededSize) {
+                escapedChars = growBuffer(escapedChars, escapedIdx, neededSize);
+            }
+            code.getChars(lastEscape, length, escapedChars, escapedIdx);
+            escapedIdx = neededSize;
+        }
+        return new String(escapedChars, 0, escapedIdx);
+    }
+
+    /**
+     * Grows the buffer to accommodate the new size.
+     * <p>
+     * This method creates a new character array with the specified size,
+     * copying the existing characters from the old buffer to the new one.
+     *
+     * @param buffer the original character buffer
+     * @param idx the current index in the buffer
+     * @param size the new size for the buffer
+     * @return a new character array with the specified size, containing the existing characters
+     */
+    private static char[] growBuffer(char[] buffer, int idx, int size) {
+        if (size < 0) {
+            throw new IllegalArgumentException("Size cannot be negative: " + size);
+        }
+        char[] newBuffer = new char[size];
+        if (idx > 0) {
+            System.arraycopy(buffer, 0, newBuffer, 0, idx);
+        }
+        return newBuffer;
+    }
+}

--- a/src/main/java/htmlflow/visitor/escape/core/CharEscaper.java
+++ b/src/main/java/htmlflow/visitor/escape/core/CharEscaper.java
@@ -1,5 +1,37 @@
+/*
+ * Copyright (C) 2009 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package htmlflow.visitor.escape.core;
 
+/**
+ * An abstract class that provides a base implementation for character escaping.
+ * <p>
+ *     This class defines the structure for escaping characters in a string,
+ *     allowing subclasses to implement specific escaping logic.
+ * </p>
+ * <p>
+ *     Derived and adapted from Guava's CharEscaper class:
+ *     <a href="https://github.com/google/guava/blob/master/guava/src/com/google/common/escape/CharEscaper.java">guava</a>
+ * </p>
+ *
+ * <p>
+ *     Modified by Arthur Oliveira on 04-08-2025
+ * </p>
+ *
+ * @author Arthur Oliveira
+ * @author The Guava Authors
+ */
 abstract class CharEscaper extends Escaper{
 
     /**
@@ -7,12 +39,22 @@ abstract class CharEscaper extends Escaper{
      */
     private static final int ESCAPE_PAD_MULTIPLIER = 2;
 
+    /**
+     * Exception message for null code input.
+     */
+    public static final String NULL_CODE_EXCEPTION_MESSAGE = "Code cannot be null";
+
+    /**
+     * Exception message for negative size in buffer growth.
+     */
+    public static final String NEGATIVE_SIZE_EXCEPTION_MESSAGE = "Size cannot be negative: ";
+
     protected CharEscaper() {}
 
     @Override
-    public String escape(String code) {
+    public String escape(String code) throws NullPointerException {
         if (code == null) {
-            throw new NullPointerException("Code cannot be null");
+            throw new NullPointerException(NULL_CODE_EXCEPTION_MESSAGE);
         }
         int length = code.length();
         for (int idx = 0; idx < length; idx++) {
@@ -27,9 +69,6 @@ abstract class CharEscaper extends Escaper{
      * Escapes a single character.
      * <p>
      *     This method is called for each character in the input string.
-     *     If the character needs to be escaped,
-     *     it should return a character array representing the escaped form.
-     *     If the character does not need to be escaped, it should return null.
      * @param c the character to escape
      * @return a character array representing the escaped form of the character,
      *         or null if the character does not need to be escaped
@@ -108,7 +147,7 @@ abstract class CharEscaper extends Escaper{
      */
     private static char[] growBuffer(char[] buffer, int idx, int size) {
         if (size < 0) {
-            throw new IllegalArgumentException("Size cannot be negative: " + size);
+            throw new IllegalArgumentException(NEGATIVE_SIZE_EXCEPTION_MESSAGE + size);
         }
         char[] newBuffer = new char[size];
         if (idx > 0) {

--- a/src/main/java/htmlflow/visitor/escape/core/Escaper.java
+++ b/src/main/java/htmlflow/visitor/escape/core/Escaper.java
@@ -1,18 +1,48 @@
+/*
+ * Copyright (C) 2009 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package htmlflow.visitor.escape.core;
 
+/**
+ * An abstract class for escaping text to make it safe for HTML output.
+ * <p>
+ * This class provides a method to escape a given string, which may involve
+ * replacing certain characters with their escaped equivalents.
+ * </p>
+ *
+ * <p>
+ *     Derived and adapted from Guava's Escaper class:
+ *     <a href="https://github.com/google/guava/blob/master/guava/src/com/google/common/escape/Escaper.java">guava</a>
+ * </p>
+ *
+ * <p>
+ *     Modified by Arthur Oliveira on 04-08-2025
+ * </p>
+ *
+ * @author Arthur Oliveira
+ * @author The Guava Authors
+ */
 public abstract class Escaper {
     protected Escaper() {}
     /**
      * Escapes the given text to make it safe for HTML output.
      * <p>
-     * Note that this method may treat input characters differently
+     * This method may treat input characters differently
      * depending on the specific escaper implementation.
      *
      * @param code the literal text to escape
      * @return the escaped text form of {@code text}
-     * @throws NullPointerException if {@code text} is null
-     * @throws IllegalArgumentException if {@code text} contains badly formed UTF-16 or cannot be escaped for any
-     * other reason
      */
     public abstract String escape(String code);
 }

--- a/src/main/java/htmlflow/visitor/escape/core/Escaper.java
+++ b/src/main/java/htmlflow/visitor/escape/core/Escaper.java
@@ -1,0 +1,18 @@
+package htmlflow.visitor.escape.core;
+
+public abstract class Escaper {
+    protected Escaper() {}
+    /**
+     * Escapes the given text to make it safe for HTML output.
+     * <p>
+     * Note that this method may treat input characters differently
+     * depending on the specific escaper implementation.
+     *
+     * @param code the literal text to escape
+     * @return the escaped text form of {@code text}
+     * @throws NullPointerException if {@code text} is null
+     * @throws IllegalArgumentException if {@code text} contains badly formed UTF-16 or cannot be escaped for any
+     * other reason
+     */
+    public abstract String escape(String code);
+}

--- a/src/main/java/htmlflow/visitor/escape/core/Escapers.java
+++ b/src/main/java/htmlflow/visitor/escape/core/Escapers.java
@@ -1,11 +1,43 @@
+/*
+ * Copyright (C) 2009 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package htmlflow.visitor.escape.core;
 
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Provides a factory for creating custom escape sequences.
+ * <p>
+ * This class allows users to define their own escape sequences by mapping characters
+ * to specific replacement strings. It is useful for escaping characters in strings
+ * that need to be processed or displayed in a specific format.
+ *
+ * <p>
+ *     Derived and adapted from Guava's Escapers class:
+ *     <a href="https://github.com/google/guava/blob/master/guava/src/com/google/common/escape/Escapers.java">guava</a>
+ * </p>
+ *
+ * <p>
+ *     Modified by Arthur Oliveira on 04-08-2025
+ * </p>
+ *
+ * @author Arthur Oliveira
+ * @author The Guava Authors
+ */
 public final class Escapers {
-    private Escapers() {
-    }
+    private Escapers() {}
 
     /**
      * Creates a new builder for constructing custom escape sequences.
@@ -23,10 +55,20 @@ public final class Escapers {
      * A builder for creating custom escape sequences.
      */
     public static final class Builder {
+        /**
+         * Exception message for null replacement input.
+         */
+        public static final String NULL_REPLACEMENT_EXCEPTION_MESSAGE = "Replacement cannot be null";
+        /**
+         * A map that holds the character to replacement string mappings.
+         * <p>
+         * The key is the character to escape, and the value is the string that
+         * will replace it in the escaped output.
+         * </p>
+         */
         private final Map<Character, String> replacementMap = new HashMap<>();
 
         private Builder() {}
-
 
         /**
          * Assigns a replacement for a character in the escape sequence.
@@ -40,21 +82,23 @@ public final class Escapers {
          */
         public Builder addScape(char character, String replacement) {
             if (replacement == null) {
-                throw new NullPointerException("Replacement cannot be null");
+                throw new NullPointerException(NULL_REPLACEMENT_EXCEPTION_MESSAGE);
             }
             replacementMap.put(character, replacement);
             return this;
         }
 
         /**
-         * TODO: Make Documentation
+         * Builds the Escaper instance based on the defined replacements.
+         *
+         * @return a new {@link Escaper} instance configured with the defined replacements
          */
         public Escaper build() {
             char safeMin = Character.MIN_VALUE;
             char safeMax = Character.MAX_VALUE;
             return new ArrayBasedCharEscaper(replacementMap, safeMin, safeMax) {
                 @Override
-                protected char[] escapeUnsafe(char c) {
+                protected char[] escapeUnsafeChar(char c) {
                     return null;
                 }
             };

--- a/src/main/java/htmlflow/visitor/escape/core/Escapers.java
+++ b/src/main/java/htmlflow/visitor/escape/core/Escapers.java
@@ -1,0 +1,65 @@
+package htmlflow.visitor.escape.core;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class Escapers {
+    private Escapers() {
+    }
+
+    /**
+     * Creates a new builder for constructing custom escape sequences.
+     * <p>
+     * This method provides a fluent interface for defining escape sequences
+     * by mapping characters to their replacement strings.
+     *
+     * @return a new {@link Builder} instance for creating custom escape sequences
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A builder for creating custom escape sequences.
+     */
+    public static final class Builder {
+        private final Map<Character, String> replacementMap = new HashMap<>();
+
+        private Builder() {}
+
+
+        /**
+         * Assigns a replacement for a character in the escape sequence.
+         * <p>
+         * If the character is already mapped, it will be replaced with the new value.
+         *
+         * @param character   the character to escape
+         * @param replacement the replacement string for the character
+         * @return this builder instance for method chaining
+         * @throws NullPointerException if {@code replacement} is null
+         */
+        public Builder addScape(char character, String replacement) {
+            if (replacement == null) {
+                throw new NullPointerException("Replacement cannot be null");
+            }
+            replacementMap.put(character, replacement);
+            return this;
+        }
+
+        /**
+         * TODO: Make Documentation
+         */
+        public Escaper build() {
+            char safeMin = Character.MIN_VALUE;
+            char safeMax = Character.MAX_VALUE;
+            return new ArrayBasedCharEscaper(replacementMap, safeMin, safeMax) {
+                @Override
+                protected char[] escapeUnsafe(char c) {
+                    return null;
+                }
+            };
+        }
+
+    }
+
+}

--- a/src/main/java/htmlflow/visitor/escape/core/Platform.java
+++ b/src/main/java/htmlflow/visitor/escape/core/Platform.java
@@ -1,0 +1,57 @@
+package htmlflow.visitor.escape.core;
+
+/**
+ * A utility class that provides a thread-local character buffer for escaping characters.
+ * <p>
+ * This class is used to manage a thread-local buffer that can be reused for character escaping,
+ * reducing the need for frequent allocations and deallocations of character arrays.
+ * <p>
+ * The buffer is initialized with a default size, and if it grows beyond this size,
+ * it will not be returned to the thread-local storage, allowing it to grow as needed.
+ */
+final class Platform {
+    private Platform() {}
+
+    /**
+     * Returns a thread-local character buffer for escaping characters.
+     * <p>
+     * This method retrieves a character array from a thread-local storage.
+     * The buffer is used to avoid frequent allocations and deallocations
+     * of character arrays during the escaping process.
+     * <p>
+     * If the buffer is null, it throws an {@link IllegalStateException}.
+     * This is a safeguard to ensure that the buffer is always available
+     * when needed for character escaping.
+     *
+     * @return a character array from the thread-local buffer
+     * @throws IllegalStateException if the thread-local buffer is null
+     */
+    static char[] charBufferFromTheadLocal() {
+        char[] buffer = THREAD_LOCAL_BUFFER.get();
+        if (buffer == null ) {
+            throw new IllegalStateException("Thread local buffer is null");
+        }
+        return buffer;
+    }
+
+    /**
+     * The size of the thread-local buffer used for character escaping.
+     */
+    private static final int BUFFER_SIZE = 1024;
+
+    /**
+     * A thread-local buffer for character escaping.
+     * <p>
+     * This buffer is used to avoid frequent allocations and deallocations
+     * of character arrays during the escaping process.
+     * <p>
+     * If it grows past the {@link #BUFFER_SIZE} it don't put it back into the thread local, it just keeps
+     * going and grows as needed.
+     */
+    private static final ThreadLocal<char[]> THREAD_LOCAL_BUFFER = new ThreadLocal<char[]>() {
+        @Override
+        protected char[] initialValue() {
+            return new char[BUFFER_SIZE];
+        }
+    };
+}

--- a/src/main/java/htmlflow/visitor/escape/core/Platform.java
+++ b/src/main/java/htmlflow/visitor/escape/core/Platform.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright (C) 2009 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package htmlflow.visitor.escape.core;
 
 /**
@@ -8,9 +22,26 @@ package htmlflow.visitor.escape.core;
  * <p>
  * The buffer is initialized with a default size, and if it grows beyond this size,
  * it will not be returned to the thread-local storage, allowing it to grow as needed.
+ *
+ * <p>
+ *     Derived and adapted from Guava's Platform class:
+ *     <a href="https://github.com/google/guava/blob/master/guava/src/com/google/common/escape/Platform.java">guava</a>
+ * </p>
+ *
+ * <p>
+ *     Modified by Arthur Oliveira on 04-08-2025
+ * </p>
+ *
+ * @author Arthur Oliveira
+ * @author The Guava Authors
  */
 final class Platform {
     private Platform() {}
+
+    /**
+     * The error message used when the thread-local buffer is null.
+     */
+    public static final String THREAD_LOCAL_BUFFER_IS_NULL = "Thread local buffer is null";
 
     /**
      * Returns a thread-local character buffer for escaping characters.
@@ -28,8 +59,8 @@ final class Platform {
      */
     static char[] charBufferFromTheadLocal() {
         char[] buffer = THREAD_LOCAL_BUFFER.get();
-        if (buffer == null ) {
-            throw new IllegalStateException("Thread local buffer is null");
+        if (buffer == null) {
+            throw new IllegalStateException(THREAD_LOCAL_BUFFER_IS_NULL);
         }
         return buffer;
     }
@@ -48,10 +79,5 @@ final class Platform {
      * If it grows past the {@link #BUFFER_SIZE} it don't put it back into the thread local, it just keeps
      * going and grows as needed.
      */
-    private static final ThreadLocal<char[]> THREAD_LOCAL_BUFFER = new ThreadLocal<char[]>() {
-        @Override
-        protected char[] initialValue() {
-            return new char[BUFFER_SIZE];
-        }
-    };
+    private static final ThreadLocal<char[]> THREAD_LOCAL_BUFFER = ThreadLocal.withInitial(() -> new char[BUFFER_SIZE]);
 }

--- a/src/test/java/htmlflow/flowifier/test/TestFlowifier.java
+++ b/src/test/java/htmlflow/flowifier/test/TestFlowifier.java
@@ -85,7 +85,7 @@ public class TestFlowifier {
 
     @Test
     public void testFlowifierTuerSourceforgeHomepage() throws Exception {
-        testFlowifier("http://tuer.sourceforge.net/en/");
+        testFlowifier("https://tuer.sourceforge.io/en/");
     }
 
     @Test

--- a/src/test/java/htmlflow/test/TestIndentation.java
+++ b/src/test/java/htmlflow/test/TestIndentation.java
@@ -38,9 +38,9 @@ import static org.junit.Assert.assertEquals;
 
 public class TestIndentation {
 
-    static final String EXPECTED = "<div><textarea>Sample text" + lineSeparator() +
+    static final String EXPECTED = "<div><textarea>Sample text\n" +
             "foo" + lineSeparator() +
-            "bar</textarea><script>// some comment" + lineSeparator() +
+            "bar</textarea><script>// some comment\n" +
             "console.log('Hello world');</script></div>";
 
     @Test
@@ -52,7 +52,7 @@ public class TestIndentation {
                         .text("Sample text\nfoo\nbar")
                     .__()
                     .script()
-                    .raw("// some comment" + lineSeparator() +
+                    .raw("// some comment\n" +
                         "console.log('Hello world');")
                 .__() // script
                 .__(); // div
@@ -69,7 +69,7 @@ public class TestIndentation {
                 .text("Sample text\nfoo\nbar")
                 .__()
                 .script()
-                .raw("// some comment" + lineSeparator() +
+                .raw("// some comment\n" +
                         "console.log('Hello world');")
                 .__() // script
                 .__()); // div
@@ -85,7 +85,7 @@ public class TestIndentation {
                 .text("Sample text\nfoo\nbar")
                 .__()
                 .script()
-                .raw("// some comment" + lineSeparator() +
+                .raw("// some comment\n" +
                         "console.log('Hello world');")
                 .__() // script
                 .__()); // div

--- a/src/test/java/htmlflow/visitor/escape/HtmlEscapersTest.java
+++ b/src/test/java/htmlflow/visitor/escape/HtmlEscapersTest.java
@@ -1,0 +1,28 @@
+package htmlflow.visitor.escape;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HtmlEscapersTest {
+
+    @Test
+    void should_scape_html_characters() {
+        String input = "Hello & <world> \"test\" 'example'";
+        String expected = "Hello &amp; &lt;world&gt; &quot;test&quot; &#39;example&#39;";
+
+        String escaped = HtmlEscapers.htmlEscaper().escape(input);
+
+        assertEquals(expected, escaped);
+    }
+
+    @Test
+    void when_no_html_characters_then_return_same_string() {
+        String input = "Hello world!";
+        String expected = "Hello world!";
+
+        String escaped = HtmlEscapers.htmlEscaper().escape(input);
+
+        assertEquals(expected, escaped);
+    }
+}

--- a/src/test/java/htmlflow/visitor/escape/core/ArrayBasedCharEscaperTest.java
+++ b/src/test/java/htmlflow/visitor/escape/core/ArrayBasedCharEscaperTest.java
@@ -1,0 +1,84 @@
+package htmlflow.visitor.escape.core;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+class ArrayBasedCharEscaperTest {
+
+    @Test
+    void when_escape_code_is_null_then_throw_NullPointerException() {
+        Map<Character, String> replacementMap = Collections.emptyMap();
+        ArrayBasedCharEscaper escaper = new ArrayBasedCharEscaper(replacementMap, Character.MIN_VALUE, Character.MAX_VALUE) {
+            @Override
+            protected char[] escapeUnsafeChar(char c) {
+                return null; // No specific escaping logic needed for this test
+            }
+        };
+
+        NullPointerException ex = assertThrows(NullPointerException.class, () -> escaper.escape(null));
+        assertEquals(ArrayBasedCharEscaper.NULL_CODE_EXCEPTION_MESSAGE, ex.getMessage());
+    }
+
+    @Test
+    void when_escape_code_is_empty_then_return_empty_string() {
+        Map<Character, String> replacementMap = Collections.emptyMap();
+        ArrayBasedCharEscaper escaper = new ArrayBasedCharEscaper(replacementMap, Character.MIN_VALUE, Character.MAX_VALUE) {
+            @Override
+            protected char[] escapeUnsafeChar(char c) {
+                return null; // No specific escaping logic needed for this test
+            }
+        };
+
+        String result = escaper.escape("");
+        assertEquals("", result);
+    }
+
+    @Test
+    void when_escape_triggers_escapeUnsafeChar_then_it_is_called() {
+        final char safeMin = (char) 10;
+        final char safeMax = (char) 20;
+        final char unsafe = (char) 25;
+        Map<Character, String> replacementMap = Collections.emptyMap();
+        ArrayBasedCharEscaper escaper = spy(new ArrayBasedCharEscaper(replacementMap, safeMin, safeMax) {
+            @Override
+            protected char[] escapeUnsafeChar(char c) {
+                return new char[]{'x'};
+            }
+        });
+
+        escaper.escape(unsafe);
+
+        verify(escaper).escapeUnsafeChar(unsafe);
+
+        final char[] expected = new char[]{'x'};
+        final char[] result = escaper.escape(unsafe);
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    void should_escape_correctly_for_safe_characters() {
+        final char safeMin = 'A';
+        final char safeMax = 'C';
+        final String escapeExample = "safeChar";
+        Map<Character, String> replacementMap = new HashMap<>();
+        replacementMap.put('B', escapeExample);
+
+        ArrayBasedCharEscaper escaper = new ArrayBasedCharEscaper(replacementMap, safeMin, safeMax) {
+            @Override
+            protected char[] escapeUnsafeChar(char c) {
+                return null; // No specific escaping logic needed for this test
+            }
+        };
+
+        String input = "A_B_C_D";
+        String result = escaper.escape(input);
+        assertEquals("A_" + escapeExample + "_C_D", result);
+    }
+}

--- a/src/test/java/htmlflow/visitor/escape/core/ArrayBasedEscaperMapTest.java
+++ b/src/test/java/htmlflow/visitor/escape/core/ArrayBasedEscaperMapTest.java
@@ -1,0 +1,44 @@
+package htmlflow.visitor.escape.core;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.max;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ArrayBasedEscaperMapTest {
+    @Test
+    void create_call_with_empty_map_should_return_empty_replacement_array() {
+        Map<Character, String> emptyMap = Collections.emptyMap();
+        ArrayBasedEscaperMap escaperMap = ArrayBasedEscaperMap.create(emptyMap);
+        assertEquals(0, escaperMap.getReplacementArray().length);
+    }
+
+    @Test
+    void create_call_with_non_empty_map_should_return_non_empty_replacement_array() {
+        final String alpha = "alpha";
+        final String beta = "beta";
+        final char alphaChar = 'a';
+        final char betaChar = 'b';
+        Map<Character, String> replacements = new HashMap<>();
+        replacements.put(alphaChar, alpha);
+        replacements.put(betaChar, beta);
+
+        ArrayBasedEscaperMap escaperMap = ArrayBasedEscaperMap.create(replacements);
+
+        char[][] replacementArray = escaperMap.getReplacementArray();
+        char maxChar = max(replacements.keySet());
+
+        assertEquals(maxChar+1, replacementArray.length);
+        assertArrayEquals(alpha.toCharArray(), replacementArray[alphaChar]);
+        assertArrayEquals(beta.toCharArray(), replacementArray[betaChar]);
+    }
+
+    @Test
+    void create_call_with_null_map_should_throw_exception() {
+        assertThrows(NullPointerException.class, () -> ArrayBasedEscaperMap.create(null));
+    }
+}

--- a/src/test/java/htmlflow/visitor/escape/core/CharEscaperTest.java
+++ b/src/test/java/htmlflow/visitor/escape/core/CharEscaperTest.java
@@ -1,0 +1,71 @@
+package htmlflow.visitor.escape.core;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+class CharEscaperTest {
+    static class TestableCharEscaper extends CharEscaper {
+        @Override
+        protected char[] escape(char c) {
+            return c == 'a' ? new char[]{'[', 'a', ']'} : null;
+        }
+
+        public String callEscapeSlow(String code, int idx) {
+            return escapeSlow(code, idx);
+        }
+    }
+
+    @Test
+    void escape_should_throw_NullPointerException_when_code_is_null() {
+        CharEscaper escaper = new CharEscaper() {
+            @Override
+            protected char[] escape(char c) {
+                return null; // No escaping logic needed for this test
+            }
+        };
+
+        NullPointerException ex = assertThrows(NullPointerException.class, () -> escaper.escape(null));
+        Assertions.assertEquals(CharEscaper.NULL_CODE_EXCEPTION_MESSAGE, ex.getMessage());
+    }
+
+    @Test
+    void escape_should_return_original_string_when_no_characters_to_escape() {
+        CharEscaper escaper = new CharEscaper() {
+            @Override
+            protected char[] escape(char c) {
+                return null; // No escaping logic needed for this test
+            }
+        };
+
+        String input = "Hello, World!";
+        String result = escaper.escape(input);
+        Assertions.assertEquals(input, result);
+    }
+
+    @Test
+    void escape_char_should_be_called_for_each_character() {
+        CharEscaper escaper = spy(new CharEscaper() {
+            @Override
+            protected char[] escape(char c) {
+                return null; // No escaping logic needed for this test
+            }
+        });
+        String input = "String";
+        escaper.escape(input);
+        for (char c : input.toCharArray()) {
+            verify(escaper).escape(c);
+        }
+    }
+
+    @Test
+    void escapeSlow_should_escape_characters_from_given_index() {
+        TestableCharEscaper escaper = new TestableCharEscaper();
+        String input = "baac";
+        String result = escaper.callEscapeSlow(input, 1);
+        Assertions.assertEquals("b[a][a]c", result);
+    }
+}

--- a/src/test/java/htmlflow/visitor/escape/core/EscapersTest.java
+++ b/src/test/java/htmlflow/visitor/escape/core/EscapersTest.java
@@ -1,0 +1,21 @@
+package htmlflow.visitor.escape.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class EscapersTest {
+    @Test
+    void when_calling_the_addScapeMethod_with_null_replacement_then_throw_exception() {
+        assertThrows(NullPointerException.class, () -> Escapers.builder().addScape('a', null));
+    }
+
+   @Test
+   void addScape_should_return_the_same_builder_instance() {
+       Escapers.Builder builder = Escapers.builder();
+       Escapers.Builder returnedBuilder = builder.addScape('a', "replacement");
+       Assertions.assertEquals(builder, returnedBuilder);
+   }
+}

--- a/src/test/java/htmlflow/visitor/escape/core/PlatformTest.java
+++ b/src/test/java/htmlflow/visitor/escape/core/PlatformTest.java
@@ -1,0 +1,13 @@
+package htmlflow.visitor.escape.core;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class PlatformTest {
+    @Test
+    void charBufferFromTheadLocal_should_return_non_null_buffer() {
+        char[] buffer = Platform.charBufferFromTheadLocal();
+        assertNotNull(buffer, "Thread local buffer should not be null");
+    }
+}

--- a/src/test/kotlin/htmlflow/test/TestKotlinExtensions.kt
+++ b/src/test/kotlin/htmlflow/test/TestKotlinExtensions.kt
@@ -13,6 +13,66 @@ data class Weather(val country: String, val locations: Iterable<Location>)
 data class Location(val city: String, val desc: String, val celsius: Int)
 
 class TestKotlinExtensions {
+
+    @Test
+    fun text_function_should_escape_html(){
+        val textToEscape = "<p>Hello, HtmlFlow!</p>"
+        val expectedHtml = """
+            <!DOCTYPE html>
+            <html>
+                <body>
+                    <div>
+                        &lt;p&gt;Hello, HtmlFlow!&lt;/p&gt;
+                    </div>
+                </body>
+            </html>
+        """.trimIndent()
+        val builder = StringBuilder()
+
+        doc(builder).html{
+            body{
+                div{
+                    text(textToEscape)
+                }
+            }
+        }
+
+        assertEquals(
+            normalizeWhitespace(builder.toString()),
+            normalizeWhitespace(expectedHtml)
+        )
+    }
+
+    @Test
+    fun when_no_escape_is_needed_text_does_not_change() {
+        val textToEscape = "Hello, HtmlFlow!"
+        val expectedHtml = """
+            <!DOCTYPE html>
+            <html>
+                <body>
+                    <div>
+                        Hello, HtmlFlow!
+                    </div>
+                </body>
+            </html>
+        """.trimIndent()
+
+        val builder = StringBuilder()
+
+        doc(builder).html {
+            body {
+                div {
+                    text(textToEscape)
+                }
+            }
+        }
+
+        assertEquals(
+            normalizeWhitespace(builder.toString()),
+            normalizeWhitespace(expectedHtml)
+        )
+    }
+
     @Test
     fun testExtensionDyn() {
         val html = weatherView.render(portugal)
@@ -414,7 +474,20 @@ class TestKotlinExtensions {
         builder.clear()
     }
 
+
+    /**
+     * Helper method to normalize whitespace in a string.
+     *
+     * This method replaces multiple spaces and tabs with a single space
+     * and trims leading and trailing whitespace.
+     *
+     * @param s The string to normalize whitespace in.
+     *
+     * @return The normalized string.
+     */
+    fun normalizeWhitespace(s: String) = s.replace(Regex("[ \\t]+"), " ").trim()
 }
+
 private val portugal = Weather("Portugal", listOf(
     Location("Porto", "Light rain", 14),
     Location("Lisbon", "Sunny day", 14),


### PR DESCRIPTION
This pull request removes the dependency on Google's Guava library by re-implementing the necessary HTML escaping utilities directly within the project. The new implementation is modular, self-contained, and based on Guava's original code (with proper attribution), allowing the project to avoid external dependencies for HTML escaping.

Key changes include:

**Dependency removal:**

* Removed the Guava dependency from `pom.xml`, eliminating the project's reliance on the external Guava library.

**HTML escaping implementation (new code):**

* Added a new `htmlflow.visitor.escape` package that provides HTML escaping functionality, including the main `HtmlEscapers` utility class, adapted from Guava.
* Implemented core escaping classes in `htmlflow.visitor.escape.core`: `Escaper`, `CharEscaper`, `ArrayBasedCharEscaper`, `ArrayBasedEscaperMap`, and `Escapers`, all adapted from Guava and now part of the project. 

**Codebase update:**

* Changed all usages of Guava's `HtmlEscapers` to the new internal `HtmlEscapers` in `htmlflow.visitor`.