### PR TITLE
fix(seo): square favicon for Google search icon

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -37,7 +37,7 @@ const codeThemeDark = withAccessibleTokens(prismThemes.oneDark, {
 const config: Config = {
   title: 'HtmlFlow',
   tagline: 'Type-safe HTML for Java and Kotlin',
-  favicon: 'img/htmlflow-logo.png',
+  favicon: 'img/htmlflow-gravatar.png',
 
   future: {
     v4: true,


### PR DESCRIPTION
## Summary
- Google's site-icon requirement is a square image; the configured favicon (`htmlflow-logo.png`, 308x264) failed that check, so search results showed no icon.
- Switched `favicon` to `htmlflow-gravatar.png` (460x460, same mark, square), which already exists in `static/img/`.

## Test plan
- [x] `yarn build` succeeds
- [x] `build/index.html` `<link rel=icon>` points to `/img/htmlflow-gravatar.png`
- [x] Confirm Google Search Console re-crawls and shows the icon (external, slow — days to weeks)